### PR TITLE
feat: empty state design, copy-to-clipboard & file info upgrade

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,6 +223,23 @@ export default function App() {
     }
   }, [fileType, fileName, getMosaicOpts, gifFrames, showToast])
 
+  const handleCopyToClipboard = useCallback(async () => {
+    if (!resultCanvasRef.current) return
+    try {
+      const blob = await new Promise<Blob | null>(resolve =>
+        resultCanvasRef.current!.toBlob(resolve, 'image/png')
+      )
+      if (blob) {
+        await navigator.clipboard.write([
+          new ClipboardItem({ 'image/png': blob })
+        ])
+        showToast('📋 已复制到剪贴板')
+      }
+    } catch {
+      showToast('❌ 复制失败，浏览器可能不支持')
+    }
+  }, [showToast])
+
   const handleReset = () => {
     stopGifPlayback()
     setFileType(null)
@@ -277,6 +294,13 @@ export default function App() {
               <div className="upload-icon" aria-hidden="true">↑</div>
               <div className="upload-title">拖拽文件到这里，或点击上传</div>
               <div className="upload-hint">支持 JPG、PNG、GIF 格式</div>
+              <div className="upload-examples" aria-hidden="true">
+                <span className="example-chip">🟦 方块</span>
+                <span className="example-chip">🔵 圆形</span>
+                <span className="example-chip">🔷 菱形</span>
+                <span className="example-chip">✖ 十字绣</span>
+                <span className="example-chip">A ASCII</span>
+              </div>
               <input type="file" accept="image/*" onChange={onFileChange} aria-label="Choose file" tabIndex={-1} />
             </div>
           ) : (
@@ -459,10 +483,15 @@ export default function App() {
             </div>
           )}
 
-          <div className="sidebar-section">
+          <div className="sidebar-section export-actions">
             <button className="btn btn-primary" disabled={!fileType || processing} onClick={handleExport} aria-label={processing ? 'Processing...' : 'Export image'}>
               {processing ? '处理中...' : fileType === 'gif' ? '导出像素 GIF' : '导出 PNG'}
             </button>
+            {fileType === 'image' && (
+              <button className="btn btn-ghost" disabled={!fileType} onClick={handleCopyToClipboard} aria-label="Copy to clipboard">
+                📋 复制到剪贴板
+              </button>
+            )}
           </div>
 
           <div className="privacy-hint">

--- a/src/index.css
+++ b/src/index.css
@@ -258,6 +258,30 @@ body {
   color: var(--text-muted);
 }
 
+/* Upload examples — show available pixel shapes */
+.upload-examples {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: var(--space-2);
+}
+
+.example-chip {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-surface);
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border-subtle);
+  transition: all var(--duration-normal) var(--ease-out);
+}
+
+.upload-zone:hover .example-chip {
+  color: var(--color-text-secondary);
+  border-color: var(--color-border);
+}
+
 /* Comparison viewer */
 .compare-wrapper {
   width: 100%;
@@ -492,11 +516,20 @@ input[type="range"]:focus::-webkit-slider-thumb {
 
 /* File info */
 .file-info {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  padding: 8px 12px;
-  background: var(--bg);
-  border-radius: 8px;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-input);
+  border-radius: var(--radius-md);
+  font-family: 'JetBrains Mono', monospace;
+  line-height: 1.6;
+}
+
+/* Export actions */
+.export-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 /* Footer hint */


### PR DESCRIPTION
## Summary

Improve the upload empty state with shape previews, add copy-to-clipboard for PNG exports, and upgrade file info display.

## Changes

### Empty State Design
- Upload zone now shows pixel shape chips (square, circle, diamond, cross-stitch, ASCII)
- Chips give users a preview of available effects before uploading
- Subtle hover animation: chips brighten when hovering the upload zone

### Copy to Clipboard
- New "Copy to clipboard" button for PNG images (next to export)
- Uses `navigator.clipboard.write()` with `ClipboardItem` API
- Graceful error handling with toast feedback if browser doesn't support it

### File Info Upgrade
- File info section now uses JetBrains Mono for consistent numeric display
- Improved spacing and background using design tokens

## Design References
- Chapter 6 (Product Recommendations) — empty state should preview the product's value
- Chapter 8 (growth.design) — Aha Moment should come as early as possible